### PR TITLE
Use the correct AdESFont when displaying the visible PAdES signature

### DIFF
--- a/library.cpp
+++ b/library.cpp
@@ -3713,7 +3713,7 @@ HRESULTERROR AdES::PDFSign(LEVEL levx, const char* d, DWORD sz, const std::vecto
 		vafter += vVisA3;
 
 		PDF::astring vv1;
-		vv1.Format("BT\n%i %i TD\n/F1 %i Tf\n(%s) Tj\nET\n", Params.pdfparams.Visible.left, Params.pdfparams.Visible.top, Params.pdfparams.Visible.fs,Params.pdfparams.Visible.t.c_str());
+		vv1.Format("BT\n%i %i TD\n/FAdESFont %i Tf\n(%s) Tj\nET\n", Params.pdfparams.Visible.left, Params.pdfparams.Visible.top, Params.pdfparams.Visible.fs,Params.pdfparams.Visible.t.c_str());
 		long long lele = vv1.length();
 		vVis1.Format("%llu 0 obj\n<</Length %llu>>stream\n%s\nendstream\nendobj\n", iVis1, lele,vv1.c_str());
 		xrefs[iVis1] = vafter.size() + res.size() + 1;


### PR DESCRIPTION
Hello, from the code it's reasonable to think that AdESFont should be used for displaying the visible PAdES signature, but instead, the font '1' is used. The '1' font caused display errors: on non-Windows-encoded PDFs, in Adobe Reader the visible signature would be displayed as a square. When the font is switched to AdESFont, the display errors were resolved.
Regards,
Aleksandar